### PR TITLE
add separarte faucet deploy step

### DIFF
--- a/deploy-kovan.sh
+++ b/deploy-kovan.sh
@@ -18,6 +18,8 @@ for token in $tokens; do
     eval "export PIP_${token}=$(jq -r ".tokens.${token} | .pip" "$CONFIG_FILE")"
 done
 
+"$LIBEXEC_DIR"/faucet-deploy
+
 "$LIBEXEC_DIR"/base-deploy
 
 "$LIBEXEC_DIR"/poll-deploy

--- a/deploy-testchain.sh
+++ b/deploy-testchain.sh
@@ -46,6 +46,8 @@ for token in $tokens; do
     fi
 done
 
+"$LIBEXEC_DIR"/faucet-deploy
+
 "$LIBEXEC_DIR"/base-deploy
 
 loadAddresses

--- a/scripts/base-deploy
+++ b/scripts/base-deploy
@@ -3,13 +3,14 @@
 # shellcheck source=lib/common.sh
 . "${LIB_DIR:-$(cd "${0%/*}/../lib"&&pwd)}/common.sh"
 
+if [[ -z "$FAUCET" ]]; then
+    echo "FAUCET must be deployed"
+    exit 1
+fi
+
 # Deploy Multicall (no solc optimization)
 dappBuild multicall
 MULTICALL=$(dappCreate multicall Multicall)
-
-# Deploy Token Faucet (no solc optimization)
-dappBuild token-faucet
-test -z "$FAUCET" && FAUCET=$(dappCreate token-faucet TokenFaucet "$(seth --to-uint256 "$(seth --to-wei 50 ETH)")")
 
 # Deploy Guard for Gov and IOU tokens (no solc optimization)
 dappBuild ds-guard

--- a/scripts/faucet-deploy
+++ b/scripts/faucet-deploy
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# shellcheck source=lib/common.sh
+. "${LIB_DIR:-$(cd "${0%/*}/../lib"&&pwd)}/common.sh"
+
+# Deploy Token Faucet (no solc optimization)
+dappBuild token-faucet
+test -z "$FAUCET" && export FAUCET=$(dappCreate token-faucet TokenFaucet "$(seth --to-uint256 "$(seth --to-wei 50 ETH)")")


### PR DESCRIPTION
Separate out faucet deploy from `base-deploy`. This does not remove the requirement that a faucet is deployed; however, it does allow for different scripts to use different faucets