### PR TITLE
nix: Update source filter to include renamed deploy scripts

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -27,7 +27,7 @@ in makerScriptPackage {
 
   # Specify files to add to build environment
   src = lib.sourceByRegex ./. [
-    ".*deploy"
+    "deploy-.*"
     ".*\.json"
     ".*scripts.*"
     ".*lib.*"


### PR DESCRIPTION
This should fix issues with 0.2.8 deployment.