### PR TITLE
Auto-manage nonces

### DIFF
--- a/deploy-goerli.json
+++ b/deploy-goerli.json
@@ -1,0 +1,200 @@
+{
+  "description": "Goerli Deployment",
+  "pauseDelay": "300",
+  "wait": "0",
+  "bump": "0.1",
+  "sump": "0.1",
+  "hump": "0",
+  "line": "1000000",
+  "flap_beg": "5",
+  "flap_ttl": "10800",
+  "flap_tau": "172800",
+  "flop_beg": "5",
+  "flop_ttl": "10800",
+  "flop_tau": "172800",
+  "setLinesMode": "direct",
+  "tokens": {
+    "ETH": {
+      "pip": {
+        "osmDelay": "0",
+        "type": "value",
+        "price": "150",
+        "signers": [
+          "0x005B903dAdfD96229CBa5EB0e5Aa75C578e8F968",
+          "0x25310bC78B9347F97DC664b46E5D4602a6De5f2C",
+          "0x74B12Eeb596831796Beb1B36FC96DCCa815523B8",
+          "0xe709290634dE56a55d9826d35A9e677Fea5422EC",
+          "0xce93de6B854E75987961533BC1FabCBA7d02BE5a",
+          "0xa072Eaf3f9EbeA5e6c3A982A37bdF275E5925bFC"
+        ]
+      },
+      "ilks": {
+        "A": {
+          "mat": "150",
+          "line": "1000",
+          "duty": "2.5",
+          "chop": "5",
+          "lump": "50",
+          "beg": "5",
+          "ttl": "10800",
+          "tau": "172800"
+        },
+        "B": {
+          "mat": "180",
+          "line": "500",
+          "duty": "1.5",
+          "chop": "5",
+          "lump": "50",
+          "beg": "5",
+          "ttl": "10800",
+          "tau": "172800"
+        },
+        "C": {
+          "mat": "250",
+          "line": "100000",
+          "duty": "0.5",
+          "chop": "5",
+          "lump": "50",
+          "beg": "5",
+          "ttl": "10800",
+          "tau": "172800"
+        }
+      }
+    },
+    "COL1": {
+      "pip": {
+        "osmDelay": "0",
+        "type": "value",
+        "price": "20",
+        "signers": [
+          "0x005B903dAdfD96229CBa5EB0e5Aa75C578e8F968",
+          "0x25310bC78B9347F97DC664b46E5D4602a6De5f2C",
+          "0x74B12Eeb596831796Beb1B36FC96DCCa815523B8",
+          "0xe709290634dE56a55d9826d35A9e677Fea5422EC",
+          "0xce93de6B854E75987961533BC1FabCBA7d02BE5a",
+          "0xa072Eaf3f9EbeA5e6c3A982A37bdF275E5925bFC"
+        ]
+      },
+      "ilks": {
+        "A": {
+          "mat": "180",
+          "line": "800",
+          "duty": "2",
+          "chop": "5",
+          "lump": "10",
+          "beg": "5",
+          "ttl": "10800",
+          "tau": "172800"
+        }
+      }
+    },
+    "COL2": {
+      "pip": {
+        "osmDelay": "0",
+        "type": "value",
+        "price": "25",
+        "signers": [
+          "0x005B903dAdfD96229CBa5EB0e5Aa75C578e8F968",
+          "0x25310bC78B9347F97DC664b46E5D4602a6De5f2C",
+          "0x74B12Eeb596831796Beb1B36FC96DCCa815523B8",
+          "0xe709290634dE56a55d9826d35A9e677Fea5422EC",
+          "0xce93de6B854E75987961533BC1FabCBA7d02BE5a",
+          "0xa072Eaf3f9EbeA5e6c3A982A37bdF275E5925bFC"
+        ]
+      },
+      "ilks": {
+        "A": {
+          "mat": "170",
+          "line": "200000",
+          "duty": "3",
+          "chop": "5",
+          "lump": "10",
+          "beg": "5",
+          "ttl": "10800",
+          "tau": "172800"
+        }
+      }
+    },
+    "COL3": {
+      "pip": {
+        "osmDelay": "0",
+        "type": "value",
+        "price": "30",
+        "signers": [
+          "0x005B903dAdfD96229CBa5EB0e5Aa75C578e8F968",
+          "0x25310bC78B9347F97DC664b46E5D4602a6De5f2C",
+          "0x74B12Eeb596831796Beb1B36FC96DCCa815523B8",
+          "0xe709290634dE56a55d9826d35A9e677Fea5422EC",
+          "0xce93de6B854E75987961533BC1FabCBA7d02BE5a",
+          "0xa072Eaf3f9EbeA5e6c3A982A37bdF275E5925bFC"
+        ]
+      },
+      "ilks": {
+        "A": {
+          "mat": "160",
+          "line": "300000",
+          "duty": "4",
+          "chop": "5",
+          "lump": "10",
+          "beg": "5",
+          "ttl": "10800",
+          "tau": "172800"
+        }
+      }
+    },
+    "COL4": {
+      "pip": {
+        "osmDelay": "0",
+        "type": "value",
+        "price": "40",
+        "signers": [
+          "0x005B903dAdfD96229CBa5EB0e5Aa75C578e8F968",
+          "0x25310bC78B9347F97DC664b46E5D4602a6De5f2C",
+          "0x74B12Eeb596831796Beb1B36FC96DCCa815523B8",
+          "0xe709290634dE56a55d9826d35A9e677Fea5422EC",
+          "0xce93de6B854E75987961533BC1FabCBA7d02BE5a",
+          "0xa072Eaf3f9EbeA5e6c3A982A37bdF275E5925bFC"
+        ]
+      },
+      "ilks": {
+        "A": {
+          "mat": "200",
+          "line": "100000",
+          "duty": "1.5",
+          "chop": "5",
+          "lump": "10",
+          "beg": "5",
+          "ttl": "10800",
+          "tau": "172800"
+        }
+      }
+    },
+    "COL5": {
+      "pip": {
+        "osmDelay": "0",
+        "type": "value",
+        "price": "50",
+        "signers": [
+          "0x005B903dAdfD96229CBa5EB0e5Aa75C578e8F968",
+          "0x25310bC78B9347F97DC664b46E5D4602a6De5f2C",
+          "0x74B12Eeb596831796Beb1B36FC96DCCa815523B8",
+          "0xe709290634dE56a55d9826d35A9e677Fea5422EC",
+          "0xce93de6B854E75987961533BC1FabCBA7d02BE5a",
+          "0xa072Eaf3f9EbeA5e6c3A982A37bdF275E5925bFC"
+        ]
+      },
+      "ilks": {
+        "A": {
+          "mat": "190",
+          "line": "200000",
+          "duty": "1.8",
+          "chop": "5",
+          "lump": "10",
+          "beg": "5",
+          "ttl": "10800",
+          "tau": "172800"
+        }
+      }
+    }
+  }
+}

--- a/deploy-goerli.sh
+++ b/deploy-goerli.sh
@@ -9,17 +9,17 @@
 
 # shellcheck source=lib/common.sh
 . "${LIB_DIR:-$(cd "${0%/*}/lib"&&pwd)}/common.sh"
-writeConfigFor "kovan"
+writeConfigFor "goerli"
 
-test "$(seth chain)" == "kovan" || exit 1
+test "$(seth chain)" == "goerli" || exit 1
 
 # Set verify contract option in Etherscan if the API key is in the config file
-etherscanApiKey=$(jq -r ".etherscanApiKey" "$CONFIG_FILE")
-if [[ "$etherscanApiKey" != "" ]]; then
-    export DAPP_VERIFY_CONTRACT="yes"
-    export ETHERSCAN_API_KEY=$etherscanApiKey
-fi
+# etherscanApiKey=$(jq -r ".etherscanApiKey" "$CONFIG_FILE")
+# if [[ "$etherscanApiKey" != "" ]]; then
+#     export DAPP_VERIFY_CONTRACT="yes"
+#     export ETHERSCAN_API_KEY=$etherscanApiKey
+# fi
 
 "$LIBEXEC_DIR"/base-deploy
 
-log "KOVAN DEPLOYMENT COMPLETED SUCCESSFULLY"
+log "GOERLI DEPLOYMENT COMPLETED SUCCESSFULLY"

--- a/deploy-testchain.sh
+++ b/deploy-testchain.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
+[[ -z $TMP_FILE ]] && {
+  nonce=$(seth nonce "$ETH_FROM")
+  TMP_FILE=$(mktemp /tmp/nonce.XXXXXX)
+  echo "$nonce" > "$TMP_FILE"
+  export TMP_FILE
+}
+
 # shellcheck source=lib/common.sh
 . "${LIB_DIR:-$(cd "${0%/*}/lib"&&pwd)}/common.sh"
 writeConfigFor "testchain"
@@ -11,7 +18,7 @@ export CASE="$LIBEXEC_DIR/cases/$1"
 # Send ETH to Omnia Relayer
 OMNIA_RELAYER=$(jq -r ".omniaFromAddr" "$CONFIG_FILE")
 export OMNIA_RELAYER
-seth send "$OMNIA_RELAYER" --value "$(seth --to-wei 10000 eth)"
+sethSend "$OMNIA_RELAYER" --value "$(seth --to-wei 10000 eth)"
 
 "$LIBEXEC_DIR"/base-deploy
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -60,11 +60,19 @@ dappBuild() {
   )
 }
 
+sethSend() {
+  export ETH_NONCE=$(cat "$TMP_FILE")
+  seth send "$@"
+  echo $((ETH_NONCE + 1)) > "$TMP_FILE"
+}
+
 dappCreate() {
+  export ETH_NONCE=$(cat "$TMP_FILE")
   local lib; lib=$1
   local class; class=$2
   DAPP_OUT="$DAPP_LIB/$lib/out" dapp create "$class" "${@:3}"
   copyAbis "$lib"
+  echo $((ETH_NONCE + 1)) > "$TMP_FILE"
 }
 
 GREEN='\033[0;32m'

--- a/scripts/base-deploy
+++ b/scripts/base-deploy
@@ -18,12 +18,12 @@ for token in $tokens; do
             signers=$(jq -r ".tokens.${token} | .pip | .signers | .[]" "$CONFIG_FILE")
             # Approve oracle price feed providers
             for signer in $signers; do
-                seth send "$(eval echo "\$PIP_${token}")" 'lift(address)' "$signer"
+                sethSend "$(eval echo "\$PIP_${token}")" 'lift(address)' "$signer"
             done
             # Set quorum for Medianizer
-            seth send "$(eval echo "\$PIP_${token}")" 'setBar(uint256)' "$(seth --to-uint256 3)"
+            sethSend "$(eval echo "\$PIP_${token}")" 'setBar(uint256)' "$(seth --to-uint256 3)"
             # Whitelist Omnia relayer to read price from Medianizer
-            seth send "$(eval echo "\$PIP_${token}")" 'kiss(address)' "$OMNIA_RELAYER"
+            sethSend "$(eval echo "\$PIP_${token}")" 'kiss(address)' "$OMNIA_RELAYER"
         fi
         # Deploy DSValue as Feed
         if [[ "${type}" == "value" ]]; then
@@ -87,11 +87,11 @@ log "core deployed"
 
 # Mint Gov Token, send to the Faucet and set permissions if a new token
 if [[ "$newGovToken" == true ]]; then
-    seth send "$MCD_GOV" 'mint(address,uint256)' "$FAUCET" "$(seth --to-uint256 "$(seth --to-wei 1000000 ETH)")"
-    seth send "$MCD_GOV" 'setAuthority(address)' "$MCD_GOV_GUARD"
-    seth send "$FAUCET" 'gulp(address)' "$MCD_GOV"
+    sethSend "$MCD_GOV" 'mint(address,uint256)' "$FAUCET" "$(seth --to-uint256 "$(seth --to-wei 1000000 ETH)")"
+    sethSend "$MCD_GOV" 'setAuthority(address)' "$MCD_GOV_GUARD"
+    sethSend "$FAUCET" 'gulp(address)' "$MCD_GOV"
     # Allow Flop to mint Gov token
-    seth send "$MCD_GOV_GUARD" 'permit(address,address,bytes32)' "$MCD_FLOP" "$MCD_GOV" "$(seth --to-bytes32 "$(seth sig 'mint(address,uint256)')")"
+    sethSend "$MCD_GOV_GUARD" 'permit(address,address,bytes32)' "$MCD_FLOP" "$MCD_GOV" "$(seth --to-bytes32 "$(seth sig 'mint(address,uint256)')")"
 fi
 
 # Deploy Collaterals (no solc optimization)
@@ -114,18 +114,18 @@ for token in $tokens; do
         rm "load-ilk-$(echo "$token" | tr '[:upper:]' '[:lower:]')-$(echo "$ilk" | tr '[:upper:]' '[:lower:]')-$(seth chain)"
 
         if [[ "$token" != "ETH" && "$newToken" == true ]]; then
-            seth send "$(eval echo "\$$token")" 'transfer(address,uint256)' "$FAUCET" "$(seth --to-uint256 "$(seth --to-wei 999000 ETH)")"
+            sethSend "$(eval echo "\$$token")" 'transfer(address,uint256)' "$FAUCET" "$(seth --to-uint256 "$(seth --to-wei 999000 ETH)")"
         fi
         export SKIP_BUILD=true
     done
 done
 
 # As all initial collaterals were deployed, we can remove authority of the deployment contract from the core contracts
-seth send "$MCD_DEPLOY" 'releaseAuth()'
+sethSend "$MCD_DEPLOY" 'releaseAuth()'
 for token in $tokens; do
     ilks=$(jq -r ".tokens.${token}.ilks | keys_unsorted[]" "$CONFIG_FILE")
     for ilk in $ilks; do
-        seth send "$MCD_DEPLOY" 'releaseAuthFlip(bytes32)' "$(seth --to-bytes32 "$(seth --from-ascii "${token}-${ilk}")")"
+        sethSend "$MCD_DEPLOY" 'releaseAuthFlip(bytes32)' "$(seth --to-bytes32 "$(seth --from-ascii "${token}-${ilk}")")"
     done
 
     log "auth removed for $token"
@@ -151,24 +151,24 @@ log "proxy actions deployed"
 dappBuild testchain-pause-proxy-actions
 
 PROXY_PAUSE_ACTIONS=$(dappCreate testchain-pause-proxy-actions TestchainPauseProxyActions)
-seth send "$PROXY_REGISTRY" 'build()'
+sethSend "$PROXY_REGISTRY" 'build()'
 log "pause actions deployed"
 
 # Get a proxy for the deployer address
 PROXY_DEPLOYER=0x"$(seth call "$PROXY_REGISTRY" 'proxies(address)(address)' "$ETH_FROM")"
 
 # Set the proxy address as root of the roles (in order to be able to do all the variables set up)
-seth send "$MCD_ADM" 'setRootUser(address,bool)' "$PROXY_DEPLOYER" true
+sethSend "$MCD_ADM" 'setRootUser(address,bool)' "$PROXY_DEPLOYER" true
 
 # Deploy chief as new $MCD_ADM (no solc optimization)
 dappBuild ds-chief
 MCD_IOU=$(dappCreate ds-chief DSToken "$(seth --to-bytes32 "$(seth --from-ascii "IOU")")")
-seth send "$MCD_IOU" 'setAuthority(address)' "$MCD_GOV_GUARD"
-seth send "$MCD_IOU" 'setOwner(address)' "0x0000000000000000000000000000000000000000"
+sethSend "$MCD_IOU" 'setAuthority(address)' "$MCD_GOV_GUARD"
+sethSend "$MCD_IOU" 'setOwner(address)' "0x0000000000000000000000000000000000000000"
 MCD_ADM=$(dappCreate ds-chief DSChief "$MCD_GOV" "$MCD_IOU" 5)
-seth send "$MCD_GOV_GUARD" 'permit(address,address,bytes32)' "$MCD_ADM" "$MCD_IOU" "$(seth --to-bytes32  "$(seth sig 'mint(address,uint256)')")"
-seth send "$MCD_GOV_GUARD" 'permit(address,address,bytes32)' "$MCD_ADM" "$MCD_IOU" "$(seth --to-bytes32  "$(seth sig 'burn(address,uint256)')")"
-seth send "$MCD_GOV_GUARD" 'setOwner(address)' "0x0000000000000000000000000000000000000000"
+sethSend "$MCD_GOV_GUARD" 'permit(address,address,bytes32)' "$MCD_ADM" "$MCD_IOU" "$(seth --to-bytes32  "$(seth sig 'mint(address,uint256)')")"
+sethSend "$MCD_GOV_GUARD" 'permit(address,address,bytes32)' "$MCD_ADM" "$MCD_IOU" "$(seth --to-bytes32  "$(seth sig 'burn(address,uint256)')")"
+sethSend "$MCD_GOV_GUARD" 'setOwner(address)' "0x0000000000000000000000000000000000000000"
 log "chief deployed"
 
 # Deploy Vote Proxy Factory (no solc optimization)

--- a/scripts/cases/crash-bite
+++ b/scripts/cases/crash-bite
@@ -15,17 +15,17 @@ done
 
 ilk=$(jq -r ".tokens.${token}.ilks | keys_unsorted[0]" "$CONFIG_FILE")
 
-seth send "$CDP_MANAGER" 'open(bytes32)' "$(seth --to-bytes32 "$(seth --from-ascii "${token}-${ilk}")")"
+sethSend "$CDP_MANAGER" 'open(bytes32)' "$(seth --to-bytes32 "$(seth --from-ascii "${token}-${ilk}")")"
 ID=$(seth call "$CDP_MANAGER" 'cdpi()(uint256)')
 URN=$(seth call "$CDP_MANAGER" 'urns(uint256)(address)' "$ID")
 
 if [[ "${token}" == "ETH" ]]; then
-    seth send "$ETH" 'deposit()' --value "$(seth --to-wei 5 ETH)"
+    sethSend "$ETH" 'deposit()' --value "$(seth --to-wei 5 ETH)"
 fi
 
-seth send "$(eval echo "\$$token")" "approve(address,uint256)" "$(eval echo "\$MCD_JOIN_${token}_${ilk}")" "$(seth --to-uint256 "$(seth --to-wei 5 ETH)")"
+sethSend "$(eval echo "\$$token")" "approve(address,uint256)" "$(eval echo "\$MCD_JOIN_${token}_${ilk}")" "$(seth --to-uint256 "$(seth --to-wei 5 ETH)")"
 
-seth send "$(eval echo "\$MCD_JOIN_${token}_${ilk}")" 'join(address,uint256)' "$URN" "$(seth --to-uint256 "$(seth --to-wei 5 ETH)")"
+sethSend "$(eval echo "\$MCD_JOIN_${token}_${ilk}")" 'join(address,uint256)' "$URN" "$(seth --to-uint256 "$(seth --to-wei 5 ETH)")"
 
 dink=$(seth --to-uint256 "$(mcd --to-hex "$(seth --to-wei 5 eth)")")
 mat=$(jq -r ".tokens.${token}.ilks.${ilk} | .mat" "$CONFIG_FILE")
@@ -34,12 +34,12 @@ dart=$(seth --to-uint256 "$(mcd --to-hex "$(seth --to-wei "$(echo "5 * $price * 
 
 "$LIBEXEC_DIR"/set-price "$token" "$price"
 
-seth send "$MCD_SPOT" 'poke(bytes32)' "$(seth --to-bytes32 "$(seth --from-ascii "${token}-${ilk}")")"
+sethSend "$MCD_SPOT" 'poke(bytes32)' "$(seth --to-bytes32 "$(seth --from-ascii "${token}-${ilk}")")"
 
-seth send "$CDP_MANAGER" 'frob(uint256,int256,int256)' "$ID" "$dink" "$dart"
+sethSend "$CDP_MANAGER" 'frob(uint256,int256,int256)' "$ID" "$dink" "$dart"
 
 "$LIBEXEC_DIR"/set-price "$token" "$(echo "$price - 1" | bc -l)"
-seth send "$MCD_SPOT" 'poke(bytes32)' "$(seth --to-bytes32 "$(seth --from-ascii "${token}-${ilk}")")"
+sethSend "$MCD_SPOT" 'poke(bytes32)' "$(seth --to-bytes32 "$(seth --from-ascii "${token}-${ilk}")")"
 
 # Bite CDP
-seth send "$MCD_CAT" 'bite(bytes32,address)' "$(seth --to-bytes32 "$(seth --from-ascii "${token}-${ilk}")")" "$URN"
+sethSend "$MCD_CAT" 'bite(bytes32,address)' "$(seth --to-bytes32 "$(seth --from-ascii "${token}-${ilk}")")" "$URN"

--- a/scripts/poll-deploy
+++ b/scripts/poll-deploy
@@ -7,7 +7,7 @@
 dappBuild gov-polling-generator
 GOV_POLL_GEN=$(dappCreate gov-polling-generator GovPollingGenerator)
 
-# tx=$(seth send --async "$GOV_POLL_GEN" 'createPoll()')
+# tx=$(sethSend --async "$GOV_POLL_GEN" 'createPoll()')
 
 # test "$(seth receipt "$tx" status)" -eq 0 && exit 1
 # number=$(seth --to-hex "$(seth receipt "$tx" blockNumber)")
@@ -17,7 +17,7 @@ GOV_POLL_GEN=$(dappCreate gov-polling-generator GovPollingGenerator)
 # VOTE_YES="0x${data:90:40}"
 # VOTE_NO="0x${data:154:40}"
 
-seth send "$GOV_POLL_GEN" 'createPoll()'
+sethSend "$GOV_POLL_GEN" 'createPoll()'
 POLL_ID=$(seth call "$GOV_POLL_GEN" 'polli()(uint256)')
 while IFS=$'\n' read -r line; do ADDRS+=("$line"); done < <(seth call "$GOV_POLL_GEN" 'polls(uint256)(address,address)' "$POLL_ID")
 POLL_ID=$((16#$POLL_ID))

--- a/scripts/set-beg
+++ b/scripts/set-beg
@@ -16,7 +16,7 @@ if [[ "$beg" != "" ]]; then
     beg=$(echo "($beg+100)"*10^25 | bc -l)
     beg=$(seth --to-uint256 "${beg%.*}")
     calldata="$(seth calldata 'file(address,address,address,bytes32,uint256)' "$MCD_PAUSE" "$MCD_GOV_ACTIONS" "$(eval echo "\$MCD_$(echo "$1" | tr '[:lower:]' '[:upper:]')")" "$(seth --to-bytes32 "$(seth --from-ascii "beg")")" "$beg")"
-    seth send "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
+    sethSend "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
 fi
 
 log "SET $(echo "$1" | tr '[:lower:]' '[:upper:]') BEG COMPLETED SUCCESSFULLY"

--- a/scripts/set-bump
+++ b/scripts/set-bump
@@ -14,7 +14,7 @@ if [[ "$bump" != "" ]]; then
     bump=$(echo "$bump"*10^45 | bc)
     bump=$(seth --to-uint256 "${bump%.*}")
     calldata="$(seth calldata 'file(address,address,address,bytes32,uint256)' "$MCD_PAUSE" "$MCD_GOV_ACTIONS" "$MCD_VOW" "$(seth --to-bytes32 "$(seth --from-ascii "bump")")" "$bump")"
-    seth send "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
+    sethSend "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
 fi
 
 log "SET BUMP COMPLETED SUCCESSFULLY"

--- a/scripts/set-hump
+++ b/scripts/set-hump
@@ -14,7 +14,7 @@ if [[ "$hump" != "" ]]; then
     hump=$(echo "$hump"*10^45 | bc)
     hump=$(seth --to-uint256 "${hump%.*}")
     calldata="$(seth calldata 'file(address,address,address,bytes32,uint256)' "$MCD_PAUSE" "$MCD_GOV_ACTIONS" "$MCD_VOW" "$(seth --to-bytes32 "$(seth --from-ascii "hump")")" "$hump")"
-    seth send "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
+    sethSend "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
 fi
 
 log "SET HUMP COMPLETED SUCCESSFULLY"

--- a/scripts/set-ilks-beg
+++ b/scripts/set-ilks-beg
@@ -16,7 +16,7 @@ for token in $tokens; do
         beg=$(echo "($beg+100)"*10^25 | bc -l)
         beg=$(seth --to-uint256 "${beg%.*}")
         calldata="$(seth calldata 'file(address,address,address,bytes32,uint256)' "$MCD_PAUSE" "$MCD_GOV_ACTIONS" "$(eval echo "\$MCD_FLIP_${token}_${ilk}")" "$(seth --to-bytes32 "$(seth --from-ascii "beg")")" "$beg")"
-        seth send "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
+        sethSend "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
     done
 done
 

--- a/scripts/set-ilks-chop
+++ b/scripts/set-ilks-chop
@@ -16,7 +16,7 @@ for token in $tokens; do
         chop=$(echo "($chop+100)"*10^25 | bc -l)
         chop=$(seth --to-uint256 "${chop%.*}")
         calldata="$(seth calldata 'file(address,address,address,bytes32,bytes32,uint256)' "$MCD_PAUSE" "$MCD_GOV_ACTIONS" "$MCD_CAT" "$(seth --to-bytes32 "$(seth --from-ascii "${token}-${ilk}")")" "$(seth --to-bytes32 "$(seth --from-ascii "chop")")" "$chop")"
-        seth send "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
+        sethSend "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
     done
 done
 

--- a/scripts/set-ilks-duty
+++ b/scripts/set-ilks-duty
@@ -16,7 +16,7 @@ for token in $tokens; do
         duty=$(bc -l <<< "scale=27; e( l(${duty} / 100 + 1)/(60 * 60 * 24 * 365)) * 10^27")
         duty=$(seth --to-uint256 "${duty%.*}")
         calldata="$(seth calldata 'file(address,address,address,bytes32,bytes32,uint256)' "$MCD_PAUSE" "$MCD_GOV_ACTIONS" "$MCD_JUG" "$(seth --to-bytes32 "$(seth --from-ascii "${token}-${ilk}")")" "$(seth --to-bytes32 "$(seth --from-ascii "duty")")" "$duty")"
-        seth send "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
+        sethSend "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
     done
 done
 

--- a/scripts/set-ilks-line
+++ b/scripts/set-ilks-line
@@ -16,7 +16,7 @@ for token in $tokens; do
         line=$(echo "$line"*10^45 | bc)
         line=$(seth --to-uint256 "${line%.*}")
         calldata="$(seth calldata 'file(address,address,address,bytes32,bytes32,uint256)' "$MCD_PAUSE" "$MCD_GOV_ACTIONS" "$MCD_VAT" "$(seth --to-bytes32 "$(seth --from-ascii "${token}-${ilk}")")" "$(seth --to-bytes32 "$(seth --from-ascii "line")")" "$line")"
-        seth send "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
+        sethSend "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
     done
 done
 

--- a/scripts/set-ilks-lump
+++ b/scripts/set-ilks-lump
@@ -16,7 +16,7 @@ for token in $tokens; do
         lump=$(echo "$lump"*10^18 | bc)
         lump=$(seth --to-uint256 "${lump%.*}")
         calldata="$(seth calldata 'file(address,address,address,bytes32,bytes32,uint256)' "$MCD_PAUSE" "$MCD_GOV_ACTIONS" "$MCD_CAT" "$(seth --to-bytes32 "$(seth --from-ascii "${token}-${ilk}")")" "$(seth --to-bytes32 "$(seth --from-ascii "lump")")" "$lump")"
-        seth send "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
+        sethSend "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
     done
 done
 

--- a/scripts/set-ilks-mat
+++ b/scripts/set-ilks-mat
@@ -16,7 +16,7 @@ for token in $tokens; do
         mat=$(echo "$mat"*10^25 | bc -l)
         mat=$(seth --to-uint256 "${mat%.*}")
         calldata="$(seth calldata 'file(address,address,address,bytes32,bytes32,uint256)' "$MCD_PAUSE" "$MCD_GOV_ACTIONS" "$MCD_SPOT" "$(seth --to-bytes32 "$(seth --from-ascii "${token}-${ilk}")")" "$(seth --to-bytes32 "$(seth --from-ascii "mat")")" "$mat")"
-        seth send "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
+        sethSend "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
     done
 done
 

--- a/scripts/set-ilks-osm
+++ b/scripts/set-ilks-osm
@@ -17,17 +17,17 @@ for token in $tokens; do
             # Deploy OSM
             eval "export PIP_${token}=$(dappCreate osm OSM "$(eval echo "\$VAL_${token}")")"
             # Set OSM delay
-            seth send "$(eval echo "\$PIP_${token}")" 'step(uint16)' "$osm_delay"
+            sethSend "$(eval echo "\$PIP_${token}")" 'step(uint16)' "$osm_delay"
             # Whitelist OSM in Medianizer (skip if source is DSValue)
             type=$(jq -r ".tokens.${token} | .pip | .type | values" "$CONFIG_FILE")
-            [[ "$type" == "median" ]] && seth send "$(eval echo "\$VAL_${token}")" 'kiss(address)' "$(eval echo "\$PIP_${token}")"
+            [[ "$type" == "median" ]] && sethSend "$(eval echo "\$VAL_${token}")" 'kiss(address)' "$(eval echo "\$PIP_${token}")"
             # Whithelist Spotter in OSM
-            seth send "$(eval echo "\$PIP_${token}")" 'kiss(address)' "$MCD_SPOT"
+            sethSend "$(eval echo "\$PIP_${token}")" 'kiss(address)' "$MCD_SPOT"
             # Set osm in spotter ilks
             ilks=$(jq -r ".tokens.${token}.ilks | keys_unsorted[]" "$CONFIG_FILE")
             for ilk in $ilks; do
                 calldata="$(seth calldata 'file(address,address,address,bytes32,address)' "$MCD_PAUSE" "$MCD_GOV_ACTIONS" "$MCD_SPOT" "$(seth --to-bytes32 "$(seth --from-ascii "${token}-${ilk}")")" "$(eval echo "\$PIP_${token}")")"
-                seth send "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
+                sethSend "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
             done
         fi
     fi

--- a/scripts/set-ilks-pip-whitelist
+++ b/scripts/set-ilks-pip-whitelist
@@ -14,7 +14,7 @@ for token in $tokens; do
     type=$(jq -r ".tokens.${token} | .pip | .type | values" "$CONFIG_FILE")
     if [[ "$addr" != "" || "$type" == "median" ]]; then
         # Whitelist Spotter in OSM or in Median
-        seth send "$(eval echo "\$PIP_${token}")" 'kiss(address)' "$MCD_SPOT"
+        sethSend "$(eval echo "\$PIP_${token}")" 'kiss(address)' "$MCD_SPOT"
     fi
 done
 

--- a/scripts/set-ilks-spell-line
+++ b/scripts/set-ilks-spell-line
@@ -22,7 +22,7 @@ done
 ilksT="[${ilksT%,}]"
 lines="[${lines%,}]"
 
-EXEC_PROPOSAL=$(seth send --create "$DAPP_LIB/line-spell/out/MultiLineSpell.bin" 'MultiLineSpell(address,address,address,bytes32[] memory,uint256[] memory)' "$MCD_PAUSE" "$MCD_GOV_ACTIONS" "$MCD_VAT" "$ilksT" "$lines")
+EXEC_PROPOSAL=$(sethSend --create "$DAPP_LIB/line-spell/out/MultiLineSpell.bin" 'MultiLineSpell(address,address,address,bytes32[] memory,uint256[] memory)' "$MCD_PAUSE" "$MCD_GOV_ACTIONS" "$MCD_VAT" "$ilksT" "$lines")
 
 # Add new addresses to json file
 addAddresses <<EOF

--- a/scripts/set-ilks-spotter-poke
+++ b/scripts/set-ilks-spotter-poke
@@ -12,7 +12,7 @@ tokens=$(jq -r ".tokens | keys_unsorted[]" "$CONFIG_FILE")
 for token in $tokens; do
     ilks=$(jq -r ".tokens.${token}.ilks | keys_unsorted[]" "$CONFIG_FILE")
     for ilk in $ilks; do
-        seth send "$MCD_SPOT" 'poke(bytes32)' "$(seth --to-bytes32 "$(seth --from-ascii "${token}-${ilk}")")"
+        sethSend "$MCD_SPOT" 'poke(bytes32)' "$(seth --to-bytes32 "$(seth --from-ascii "${token}-${ilk}")")"
     done
 done
 

--- a/scripts/set-ilks-tau
+++ b/scripts/set-ilks-tau
@@ -14,7 +14,7 @@ for token in $tokens; do
     for ilk in $ilks; do
         tau=$(jq -r ".tokens.${token}.ilks.${ilk} | .tau" "$CONFIG_FILE")
         calldata="$(seth calldata 'file(address,address,address,bytes32,uint256)' "$MCD_PAUSE" "$MCD_GOV_ACTIONS" "$(eval echo "\$MCD_FLIP_${token}_${ilk}")" "$(seth --to-bytes32 "$(seth --from-ascii "tau")")" "$tau")"
-        seth send "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
+        sethSend "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
     done
 done
 

--- a/scripts/set-ilks-ttl
+++ b/scripts/set-ilks-ttl
@@ -14,7 +14,7 @@ for token in $tokens; do
     for ilk in $ilks; do
         ttl=$(jq -r ".tokens.${token}.ilks.${ilk} | .ttl" "$CONFIG_FILE")
         calldata="$(seth calldata 'file(address,address,address,bytes32,uint256)' "$MCD_PAUSE" "$MCD_GOV_ACTIONS" "$(eval echo "\$MCD_FLIP_${token}_${ilk}")" "$(seth --to-bytes32 "$(seth --from-ascii "ttl")")" "$ttl")"
-        seth send "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
+        sethSend "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
     done
 done
 

--- a/scripts/set-line
+++ b/scripts/set-line
@@ -14,7 +14,7 @@ if [[ "$Line" != "" ]]; then
     Line=$(echo "$Line"*10^45 | bc)
     Line=$(seth --to-uint256 "${Line%.*}")
     calldata="$(seth calldata 'file(address,address,address,bytes32,uint256)' "$MCD_PAUSE" "$MCD_GOV_ACTIONS" "$MCD_VAT" "$(seth --to-bytes32 "$(seth --from-ascii "Line")")" "$Line")"
-    seth send "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
+    sethSend "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
 fi
 
 log "SET LINE COMPLETED SUCCESSFULLY"

--- a/scripts/set-pause-auth-delay
+++ b/scripts/set-pause-auth-delay
@@ -12,6 +12,6 @@ delay=$(jq -r ".pauseDelay" "$CONFIG_FILE")
 loadAddresses
 
 calldata="$(seth calldata 'setAuthorityAndDelay(address,address,address,uint256)' "$MCD_PAUSE" "$MCD_GOV_ACTIONS" "$MCD_ADM" "$(seth --to-uint256 "$delay")")"
-seth send "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
+sethSend "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
 
 log "SET PAUSE AUTH DELAY COMPLETED SUCCESSFULLY"

--- a/scripts/set-price
+++ b/scripts/set-price
@@ -11,12 +11,12 @@ loadAddresses
 type=$(jq -r ".tokens.${1} | .pip | .type" "$CONFIG_FILE")
 if [[ "$type" == "value" ]]; then
     # Set DSValue price
-    eval seth send "\$VAL_${1} 'poke(bytes32)' $(seth --to-uint256 "$(seth --to-wei "$2" ETH)")"
+    eval sethSend "\$VAL_${1} 'poke(bytes32)' $(seth --to-uint256 "$(seth --to-wei "$2" ETH)")"
 fi
 
 if [[ "$(eval echo "\$PIP_${1}")" != "$(eval echo "\$VAL_${1}")" ]]; then
     # Poke OSM
-    seth send "$(eval echo "\$PIP_${1}")" 'poke()'
+    sethSend "$(eval echo "\$PIP_${1}")" 'poke()'
 fi
 
 log "SET PRICE COMPLETED SUCCESSFULLY"

--- a/scripts/set-sump
+++ b/scripts/set-sump
@@ -14,7 +14,7 @@ if [[ "$sump" != "" ]]; then
     sump=$(echo "$sump"*10^45 | bc)
     sump=$(seth --to-uint256 "${sump%.*}")
     calldata="$(seth calldata 'file(address,address,address,bytes32,uint256)' "$MCD_PAUSE" "$MCD_GOV_ACTIONS" "$MCD_VOW" "$(seth --to-bytes32 "$(seth --from-ascii "sump")")" "$sump")"
-    seth send "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
+    sethSend "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
 fi
 
 log "SET SUMP COMPLETED SUCCESSFULLY"

--- a/scripts/set-tau
+++ b/scripts/set-tau
@@ -14,7 +14,7 @@ loadAddresses
 tau=$(jq -r ".$1_tau | values" "$CONFIG_FILE")
 if [[ "$tau" != "" ]]; then
     calldata="$(seth calldata 'file(address,address,address,bytes32,uint256)' "$MCD_PAUSE" "$MCD_GOV_ACTIONS" "$(eval echo "\$MCD_$(echo "$1" | tr '[:lower:]' '[:upper:]')")" "$(seth --to-bytes32 "$(seth --from-ascii "tau")")" "$tau")"
-    seth send "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
+    sethSend "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
 fi
 
 log "SET $(echo "$1" | tr '[:lower:]' '[:upper:]') TAU COMPLETED SUCCESSFULLY"

--- a/scripts/set-ttl
+++ b/scripts/set-ttl
@@ -14,7 +14,7 @@ loadAddresses
 ttl=$(jq -r ".$1_ttl | values" "$CONFIG_FILE")
 if [[ "$ttl" != "" ]]; then
     calldata="$(seth calldata 'file(address,address,address,bytes32,uint256)' "$MCD_PAUSE" "$MCD_GOV_ACTIONS" "$(eval echo "\$MCD_$(echo "$1" | tr '[:lower:]' '[:upper:]')")" "$(seth --to-bytes32 "$(seth --from-ascii "ttl")")" "$ttl")"
-    seth send "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
+    sethSend "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
 fi
 
 log "SET $(echo "$1" | tr '[:lower:]' '[:upper:]') TTL COMPLETED SUCCESSFULLY"

--- a/scripts/set-wait
+++ b/scripts/set-wait
@@ -12,7 +12,7 @@ loadAddresses
 wait=$(jq -r ".wait | values" "$CONFIG_FILE")
 if [[ "$wait" != "" ]]; then
     calldata="$(seth calldata 'file(address,address,address,bytes32,uint256)' "$MCD_PAUSE" "$MCD_GOV_ACTIONS" "$MCD_VOW" "$(seth --to-bytes32 "$(seth --from-ascii "wait")")" "$wait")"
-    seth send "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
+    sethSend "$PROXY_DEPLOYER" 'execute(address,bytes memory)' "$PROXY_PAUSE_ACTIONS" "$calldata"
 fi
 
 log "SET WAIT COMPLETED SUCCESSFULLY"


### PR DESCRIPTION
With this commit, deploying to Goerli works. Tested with Goerli, Kovan and dapp testnet.

Replace any `seth` send with `sethSend` and any dapp create with `dappCreate`

Created `./deploy-goerli.sh` with most of the config from `deploy-testchain.json`, so it creates Oracles for now, since we don't have any running yet on Goerli.

Depends on https://github.com/makerdao/dss-deploy/pull/38