### PR TITLE
travis: fix shellcheck installatoin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
   - echo "trusted-users = root $USER" | sudo tee -a /etc/nix/nix.conf
 script:
   - |
-    nix-env -iA shellcheck
+    nix-env -iA shellcheck -f '<nixpkgs>'
     # for some reason, `find` with multiple search paths piped to xargs
     # produces no output
     find lib -type f -print | xargs shellcheck -x


### PR DESCRIPTION
The source needs to be specified, for some reason.

Alternatively, we could do `nix-env -iA ShellCheck` but that doesn't work on my 19.03 machine, so I suspect it's less future-proof.