### PR TITLE
Copy median abis

### DIFF
--- a/scripts/base-deploy
+++ b/scripts/base-deploy
@@ -6,6 +6,7 @@
 # Deploy Values or Medians + OSMs (if delay > 0) (no solc optimization)
 dappBuild osm
 dappBuild testchain-medians
+copyAbis testchain-medians
 
 tokens=$(jq -r ".tokens | keys_unsorted[]" "$CONFIG_FILE")
 for token in $tokens; do

--- a/scripts/base-deploy
+++ b/scripts/base-deploy
@@ -6,7 +6,6 @@
 # Deploy Values or Medians + OSMs (if delay > 0) (no solc optimization)
 dappBuild osm
 dappBuild testchain-medians
-copyAbis testchain-medians
 
 tokens=$(jq -r ".tokens | keys_unsorted[]" "$CONFIG_FILE")
 for token in $tokens; do
@@ -32,6 +31,8 @@ for token in $tokens; do
         fi
     else
         eval "export PIP_${token}=${pipAddr}"
+        copyAbis osm
+        copyAbis testchain-medians
     fi
     eval "export VAL_${token}=\$PIP_${token}"
 done


### PR DESCRIPTION
When we are using an existing median we are not copying the Median or OSM abis after `dappBuild` This adds those ABIs to the `out/abi` directory