### PR TITLE
STAX-10 Add `githubAuthToken` arg to nix expressions

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,7 @@
 , pkgs ? (import ./nix/pkgs.nix { inherit pkgsSrc; }).pkgs
 , dss-deploy ? null
 , doCheck ? false
+, githubAuthToken ? null
 }@args: with pkgs;
 
 let


### PR DESCRIPTION
Added the argument `githubAuthToken` to `default.nix` and `shell.nix` to allow fetching dependencies that are in private GitHub repos.

E.g. `nix-build` or `nix-shell --argstr githubAuthToken some-github-api-token`