### PR TITLE
Reenable verification

### DIFF
--- a/deploy-kovan.sh
+++ b/deploy-kovan.sh
@@ -6,12 +6,12 @@ writeConfigFor "kovan"
 
 test "$(seth chain)" == "kovan" || exit 1
 
-# Set verify contract option in Etherscan if the API key is in the config file
-# etherscanApiKey=$(jq -r ".etherscanApiKey" "$CONFIG_FILE")
-# if [[ "$etherscanApiKey" != "" ]]; then
-#     export DAPP_VERIFY_CONTRACT="yes"
-#     export ETHERSCAN_API_KEY=$etherscanApiKey
-# fi
+#Set verify contract option in Etherscan if the API key is in the config file
+etherscanApiKey=$(jq -r ".etherscanApiKey" "$CONFIG_FILE")
+if [[ "$etherscanApiKey" != "" ]]; then
+    export DAPP_VERIFY_CONTRACT="yes"
+    export ETHERSCAN_API_KEY=$etherscanApiKey
+fi
 
 export DEPLOY_RESTRICTED_FAUCET="no"
 "$LIBEXEC_DIR"/base-deploy

--- a/deploy-main.sh
+++ b/deploy-main.sh
@@ -6,6 +6,13 @@ writeConfigFor "main"
 
 test "$(seth chain)" == "ethlive" || exit 1
 
+#Set verify contract option in Etherscan if the API key is in the config file
+etherscanApiKey=$(jq -r ".etherscanApiKey" "$CONFIG_FILE")
+if [[ "$etherscanApiKey" != "" ]]; then
+    export DAPP_VERIFY_CONTRACT="yes"
+    export ETHERSCAN_API_KEY=$etherscanApiKey
+fi
+
 export DEPLOY_RESTRICTED_FAUCET="yes"
 "$LIBEXEC_DIR"/base-deploy
 


### PR DESCRIPTION
Fixes to dapptools verify have been merged at https://github.com/dapphub/dapptools/pull/287

This re-enables the etherscan verification flags for the kovan deployment and adds them to the script for the mainnet deployment.

Will require a dapptools update to work.