### PR TITLE
Add hevm and jshon to the nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -18,6 +18,8 @@ in mkShell {
     tdds
     dapp2nix
     procps
+    hevm
+    jshon
   ];
 
   shellHook = ''


### PR DESCRIPTION
Contract verification dependencies.