### PR TITLE
Add tee command to log all console output for auditing and reconstruction

### DIFF
--- a/deploy-kovan.sh
+++ b/deploy-kovan.sh
@@ -7,6 +7,6 @@ writeConfigFor "kovan"
 test "$(seth chain)" == "kovan" || exit 1
 
 export DEPLOY_RESTRICTED_FAUCET="no"
-"$LIBEXEC_DIR"/base-deploy
+"$LIBEXEC_DIR"/base-deploy |& tee "$OUT_DIR/dss_kovan.log"
 
 log "KOVAN DEPLOYMENT COMPLETED SUCCESSFULLY"

--- a/deploy-main.sh
+++ b/deploy-main.sh
@@ -7,6 +7,6 @@ writeConfigFor "main"
 test "$(seth chain)" == "ethlive" || exit 1
 
 export DEPLOY_RESTRICTED_FAUCET="yes"
-"$LIBEXEC_DIR"/base-deploy
+"$LIBEXEC_DIR"/base-deploy |& tee "$OUT_DIR/dss_mainnet.log"
 
 log "MAINNET DEPLOYMENT COMPLETED SUCCESSFULLY"

--- a/deploy-testchain.sh
+++ b/deploy-testchain.sh
@@ -13,7 +13,7 @@ OMNIA_RELAYER=$(jq -r ".omniaFromAddr" "$CONFIG_FILE")
 seth send "$OMNIA_RELAYER" --value "$(seth --to-wei 10000 eth)"
 
 export DEPLOY_RESTRICTED_FAUCET="no"
-"$LIBEXEC_DIR"/base-deploy
+"$LIBEXEC_DIR"/base-deploy |& tee "$OUT_DIR/dss_testchain.log"
 
 if [[ -f "$CASE" ]]; then
     log "TESTCHAIN DEPLOYMENT + ${1} COMPLETED SUCCESSFULLY"


### PR DESCRIPTION
Adds a `tee` command to the `base-deploy` calls to capture all deployment output in a log file.

Many addresses are created dynamically in the deployment process and capturing the output logs here can help with forensic analysis of the deployment process.