### PR TITLE
Use contract dependencies directly instead of transitively

### DIFF
--- a/.dapp.json
+++ b/.dapp.json
@@ -454,7 +454,13 @@
   },
   "this": {
     "deps": {
+      "ds-chief": "ds-chief_73e6889",
+      "ds-proxy": "ds-proxy_4299be4",
+      "ds-roles": "ds-roles_dbd4c1a",
+      "ds-token": "ds-token_8943920",
+      "ds-value": "ds-value_0bc3c89",
       "dsr-manager": "dsr-manager_4e897cf",
+      "dss-cdp-manager": "dss-cdp-manager_85fbf70",
       "dss-deploy": "dss-deploy_6a4e63d",
       "dss-deploy-pause-proxy-actions": "dss-deploy-pause-proxy-actions_7a78bfe",
       "dss-proxy-actions": "dss-proxy-actions_b376af8",
@@ -463,6 +469,7 @@
       "multicall": "multicall_57967fc",
       "osm": "osm_583fdc6",
       "osm-mom": "osm-mom_0a806ab",
+      "proxy-registry": "proxy-registry_acc9b3c",
       "testchain-medians": "testchain-medians_1950220",
       "token-faucet": "token-faucet_a9f6a40",
       "vote-proxy": "vote-proxy_2018680"

--- a/libexec/base-deploy
+++ b/libexec/base-deploy
@@ -41,7 +41,7 @@ for token in $tokens; do
         fi
         # Deploy DSValue as Feed
         if [[ "${type}" == "value" ]]; then
-            contract=$(dappCreate osm DSValue)
+            contract=$(dappCreate ds-value DSValue)
             eval "export VAL_${token}=${contract}"
             log "VAL_${token}=$(eval "echo ${contract}")"
         fi
@@ -72,9 +72,9 @@ fi
 # Deploy ProxyRegistry
 PROXY_REGISTRY=$(jq -r ".import.proxyRegistry | values" "$CONFIG_FILE")
 if [[ -z "$PROXY_REGISTRY" ]]; then
-    PROXY_FACTORY=$(dappCreate dss-proxy-actions DSProxyFactory)
+    PROXY_FACTORY=$(dappCreate ds-proxy DSProxyFactory)
     log "PROXY_FACTORY=$PROXY_FACTORY"
-    PROXY_REGISTRY=$(dappCreate dss-proxy-actions ProxyRegistry "$PROXY_FACTORY")
+    PROXY_REGISTRY=$(dappCreate proxy-registry ProxyRegistry "$PROXY_FACTORY")
     log "PROXY_REGISTRY=$PROXY_REGISTRY"
 else
     PROXY_FACTORY=$(seth storage "$PROXY_REGISTRY" 1)
@@ -164,9 +164,9 @@ PROXY_ACTIONS_DSR=$(dappCreate dss-proxy-actions-optimized DssProxyActionsDsr)
 log "PROXY_ACTIONS_DSR=$PROXY_ACTIONS_DSR"
 
 # Deploy CdpManager
-CDP_MANAGER=$(dappCreate dss-proxy-actions DssCdpManager "$MCD_VAT")
+CDP_MANAGER=$(dappCreate dss-cdp-manager DssCdpManager "$MCD_VAT")
 log "CDP_MANAGER=$CDP_MANAGER"
-GET_CDPS=$(dappCreate dss-proxy-actions GetCdps)
+GET_CDPS=$(dappCreate dss-cdp-manager GetCdps)
 log "GET_CDPS=$GET_CDPS"
 
 # Deploy DsrManager
@@ -217,10 +217,10 @@ sethSend "$MCD_ADM" 'setRootUser(address,bool)' "$PROXY_DEPLOYER" true
 # Deploy chief as new $MCD_ADM if there isn't an authority in the config file
 MCD_ADM=$(jq -r ".import.authority | values" "$CONFIG_FILE")
 if [[ -z "$MCD_ADM" ]]; then
-    MCD_IOU=$(dappCreate vote-proxy DSToken "$(seth --to-bytes32 "$(seth --from-ascii "IOU")")")
+    MCD_IOU=$(dappCreate ds-token DSToken "$(seth --to-bytes32 "$(seth --from-ascii "IOU")")")
     log "MCD_IOU=$MCD_IOU"
 
-    MCD_ADM=$(dappCreate vote-proxy DSChief "$MCD_GOV" "$MCD_IOU" 5)
+    MCD_ADM=$(dappCreate ds-chief DSChief "$MCD_GOV" "$MCD_IOU" 5)
     log "MCD_ADM=$MCD_ADM"
     sethSend "$MCD_IOU" 'setOwner(address)' "${MCD_ADM}"
 

--- a/libexec/dss/deploy-core
+++ b/libexec/dss/deploy-core
@@ -21,7 +21,7 @@
 # If no Governance token is defined, create one
 if [ -z "$MCD_GOV" ]
 then
-    MCD_GOV=$(dappCreate dss-deploy DSToken "$(seth --to-bytes32 "$(seth --from-ascii "MKR")")")
+    MCD_GOV=$(dappCreate ds-token DSToken "$(seth --to-bytes32 "$(seth --from-ascii "MKR")")")
     log "MCD_GOV=$MCD_GOV"
 fi
 
@@ -32,7 +32,7 @@ log "MCD_DEPLOY=$MCD_DEPLOY"
 # If no Authority is defined, create one
 if [ -z "$MCD_ADM" ]
 then
-    MCD_ADM=$(dappCreate dss-deploy DSRoles)
+    MCD_ADM=$(dappCreate ds-roles DSRoles)
     log "MCD_ADM=$MCD_ADM"
     sethSend "$MCD_ADM" 'setRootUser(address,bool)' "$ETH_FROM" true
 fi


### PR DESCRIPTION
This PR should enable us to remove `*.t.sol` files from being built in `solidityPackage`.