### PR TITLE
Override ilk-registry and dss-proxy-actions dapp packages with optimi…

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -41,10 +41,9 @@ let
   # Create derivations from lock file data
   packages = packageSpecs (deps' // {
     # Package overrides
-    ilk-registry = deps'.ilk-registry                     // { solc = solc-versions.solc_0_6_7; };
-    ilk-registry-optimized = deps'.ilk-registry           // { name = "ilk-registry-optimized";      solcFlags = "--optimize"; solc = solc-versions.solc_0_6_7; };
-    dss-proxy-actions-optimized = deps'.dss-proxy-actions // { name = "dss-proxy-actions-optimized"; solcFlags = "--optimize"; };
-    dss-deploy-optimized = deps'.dss-deploy               // { name = "dss-deploy-optimized";        solcFlags = "--optimize"; };
+    ilk-registry = deps'.ilk-registry           // { name = "ilk-registry-optimized";      solcFlags = "--optimize"; solc = solc-versions.solc_0_6_7; };
+    dss-proxy-actions = deps'.dss-proxy-actions // { name = "dss-proxy-actions-optimized"; solcFlags = "--optimize"; };
+    dss-deploy-optimized = deps'.dss-deploy     // { name = "dss-deploy-optimized";        solcFlags = "--optimize"; };
   });
 
 in makerScriptPackage {


### PR DESCRIPTION
…ze solc flag

Instead of adding `ilk-registry-optimized` and `dss-proxy-actions-optimized` derivations we just override the existing ones, avoiding duplicate dapp packages that aren't needed.