### PR TITLE
[WIP] feat: Add UNI-V2-USDC-ETH-A Collateral (SC-8095)

### DIFF
--- a/config/kovan.json
+++ b/config/kovan.json
@@ -574,6 +574,32 @@
           "tau": "3600"
         }
       }
+    },
+    "UNIV2USDCETH": {
+      "import": {
+        "gem": "0x44892ab8F7aFfB7e1AdA4Fb956CCE2a2f3049619",
+        "pip": "0x627969F6fe0651a703B2d0e3a5758F9fF9B7547A"
+      },
+      "joinDeploy": {
+        "src": "GemJoin",
+        "extraParams": []
+      },
+      "ilks": {
+        "A": {
+          "mat": "125",
+          "line": "10000000",
+          "autoLine": "0",
+          "autoLineGap": "0",
+          "autoLineTtl": "0",
+          "dust": "500",
+          "duty": "1",
+          "chop": "13",
+          "dunk": "50000",
+          "beg": "3",
+          "ttl": "21600",
+          "tau": "21600"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
I deployed an Oracle to Kovan using the following parameters:

gem: 0x44892ab8F7aFfB7e1AdA4Fb956CCE2a2f3049619
wat: UNIV2-USDC-ETH-LP-ORACLE
median USDC: 0x4c51c2584309b7BF328F89609FDd03B3b95fC677
median ETH: 0x0E30F0FC91FDbc4594b1e2E5d64E6F1f94cAB23D

The oracle's address is: 0x627969F6fe0651a703B2d0e3a5758F9fF9B7547A

Note: I haven't `deny`ed myself yet.